### PR TITLE
Add starshot-prototype as submodule

### DIFF
--- a/.devpanel/init.sh
+++ b/.devpanel/init.sh
@@ -17,10 +17,8 @@
 
 STATIC_FILES_PATH="$WEB_ROOT/sites/default/files"
 SETTINGS_FILES_PATH="$WEB_ROOT/sites/default/settings.php"
-#== Clone source code
-if [ ! -d "$APP_ROOT/starshot-prototype" ]; then
-  git clone https://github.com/phenaproxima/starshot-prototype.git starshot-prototype
-fi
+#== Update source code
+git submodule update --remote starshot-prototype
 
 #== Setup settings.php file
 sudo cp $APP_ROOT/.devpanel/drupal-settings.php $SETTINGS_FILES_PATH

--- a/.devpanel/init.sh
+++ b/.devpanel/init.sh
@@ -18,7 +18,7 @@
 STATIC_FILES_PATH="$WEB_ROOT/sites/default/files"
 SETTINGS_FILES_PATH="$WEB_ROOT/sites/default/settings.php"
 #== Update source code
-git submodule update --remote starshot-prototype
+git submodule update --init --remote --recursive
 
 #== Setup settings.php file
 sudo cp $APP_ROOT/.devpanel/drupal-settings.php $SETTINGS_FILES_PATH

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-starshot-prototype

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "starshot-prototype"]
+	path = starshot-prototype
+	url = https://github.com/phenaproxima/starshot-prototype.git


### PR DESCRIPTION
This requires the `--recurse-submodules` option when [cloning](https://git-scm.com/book/en/v2/Git-Tools-Submodules#_cloning_submodules).