### PR TITLE
Add starshot-prototype as submodule

### DIFF
--- a/.devpanel/init.sh
+++ b/.devpanel/init.sh
@@ -17,15 +17,17 @@
 
 STATIC_FILES_PATH="$WEB_ROOT/sites/default/files"
 SETTINGS_FILES_PATH="$WEB_ROOT/sites/default/settings.php"
-#== Update source code
-git submodule update --init --remote --recursive
+#== Clone source code
+if [ -z "$(ls -A $APP_ROOT/starshot-prototype)" ]; then
+  git submodule update --init --remote --recursive
+  cd $APP_ROOT/starshot-prototype
+  git checkout main
+fi
 
 #== Setup settings.php file
 sudo cp $APP_ROOT/.devpanel/drupal-settings.php $SETTINGS_FILES_PATH
 
 #== Composer install.
-cd $APP_ROOT/starshot-prototype
-git checkout main
 composer install;
 
 #== Site install.

--- a/.devpanel/init.sh
+++ b/.devpanel/init.sh
@@ -17,10 +17,8 @@
 
 STATIC_FILES_PATH="$WEB_ROOT/sites/default/files"
 SETTINGS_FILES_PATH="$WEB_ROOT/sites/default/settings.php"
-#== Clone source code
-if [ ! -d "$APP_ROOT/starshot-prototype" ]; then
-  git clone https://github.com/phenaproxima/starshot-prototype.git starshot-prototype
-fi
+#== Update source code
+git submodule update --remote starshot-prototype
 
 #== Setup settings.php file
 sudo cp $APP_ROOT/.devpanel/drupal-settings.php $SETTINGS_FILES_PATH

--- a/.devpanel/init.sh
+++ b/.devpanel/init.sh
@@ -18,7 +18,7 @@
 STATIC_FILES_PATH="$WEB_ROOT/sites/default/files"
 SETTINGS_FILES_PATH="$WEB_ROOT/sites/default/settings.php"
 #== Update source code
-git submodule update --remote starshot-prototype
+git submodule update --init --remote --recursive
 
 #== Setup settings.php file
 sudo cp $APP_ROOT/.devpanel/drupal-settings.php $SETTINGS_FILES_PATH

--- a/.devpanel/init.sh
+++ b/.devpanel/init.sh
@@ -25,6 +25,7 @@ sudo cp $APP_ROOT/.devpanel/drupal-settings.php $SETTINGS_FILES_PATH
 
 #== Composer install.
 cd $APP_ROOT/starshot-prototype
+git checkout main
 composer install;
 
 #== Site install.

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-starshot-prototype

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "starshot-prototype"]
+	path = starshot-prototype
+	url = https://github.com/phenaproxima/starshot-prototype.git


### PR DESCRIPTION
#1

Test steps:
1. Launch the Starshot app on Drupal Forge.
2. Open the project in DevPanel and sync all branches.
3. Build app from scratch for submodule branch.
    - Set web root to /var/www/html/starshot-prototype/web.